### PR TITLE
Add python-requests as an additional requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(
 
     },
     install_requires = [
-        "pyyaml"
+        "pyyaml",
+        "requests"
     ],
     author = "Adfinis-SyGroup AG",
     author_email = "https://adfinis-sygroup.ch/",


### PR DESCRIPTION
This commit adds python-requests to the installation requirements in setup.py and solves #14.
