### PR TITLE
Add subnet-type to support IPv6 subnets

### DIFF
--- a/foremanclient/importer.py
+++ b/foremanclient/importer.py
@@ -246,7 +246,8 @@ class ForemanImport(foremanclient.ForemanBase):
                     'from':             subnet['from'],
                     'to':               subnet['to'],
                     'vlanid':           subnet['vlanid'],
-                    'boot_mode':        subnet['boot-mode']
+                    'boot_mode':        subnet['boot-mode'],
+                    'network_type':     subnet['network-type'],
                 }
 
                 if add_domain: subnet_tpl['domain_ids'] = add_domain

--- a/foremanclient/validator.py
+++ b/foremanclient/validator.py
@@ -138,6 +138,7 @@ class Validator:
             Optional('tftp-proxy'):                     Any(str, None),
             Optional('dns-proxy'):                      Any(str, None),
             Optional('boot-mode'):                      Any('Static', 'DHCP', None),
+            Optional('network-type'):                   Any('IPv4', 'IPv6', None),
         })
 
         self.cleanup_arch = Schema({


### PR DESCRIPTION
This will still default to IPv4 when omitted, but this
partial snippet will add an IPv6 subnet:

```
  - name: my-v6-subnet
    network-type: IPv6
    network: "2001:db8:0000:1010::"
    mask: "ffff:ffff:ffff:ffff::"
    dns-primary: "2001:4860:4860::8888"
    dns-secondary: "2001:4860:4860::8844"
    (...)
```

This should fix #32 