### PR TITLE
Fix cleanup of locked provisioning templates

### DIFF
--- a/foreman_yml/cleanup.py
+++ b/foreman_yml/cleanup.py
@@ -5,6 +5,7 @@ import log
 from base import ForemanBase
 from voluptuous import MultipleInvalid
 
+from pprint import pprint
 
 class ForemanCleanup(ForemanBase):
 
@@ -105,7 +106,13 @@ class ForemanCleanup(ForemanBase):
                 if (ptc['name'] == pt['name']):
                     pt_deleted = True
                     log.log(log.LOG_INFO, "Delete Provisioning Template '{0}'".format(pt['name']))
-
+                    ptinfo = self.fm.provisioning_templates.show(pt['name'])
+                    if ptinfo['locked']:
+                        log.log(log.LOG_INFO, "Provisioning Template '{0}' is locked, unlock first".format(pt['name']))
+                        self.fm.provisioning_templates.update(
+                            { 'locked': False },
+                            ptinfo['id']
+                        )
                     self.fm.provisioning_templates.destroy( pt['name'] )
                     continue
             if not pt_deleted:

--- a/foreman_yml/cleanup.py
+++ b/foreman_yml/cleanup.py
@@ -5,8 +5,6 @@ import log
 from base import ForemanBase
 from voluptuous import MultipleInvalid
 
-from pprint import pprint
-
 class ForemanCleanup(ForemanBase):
 
     def process_cleanup_arch(self):

--- a/foreman_yml/main.py
+++ b/foreman_yml/main.py
@@ -125,6 +125,7 @@ def main():
 
     if (function == "cleanup"):
         fm = ForemanCleanup(config)
+        fm.connect()
         fm_cleanup(fm)
 
     if (function == "legacy"):


### PR DESCRIPTION
This PR will fix the deletion of locked provisioning templates and an issue with connecting to foreman when using the syntax `foreman-yml cleanup ..`

This fixes #56 