### PR TITLE
Bugfix/yaml loader

### DIFF
--- a/foreman_yml/main.py
+++ b/foreman_yml/main.py
@@ -107,7 +107,7 @@ def main():
 
     try:
         config_file = open(config_file, 'r')
-        config = yaml.load(config_file)
+        config = yaml.load(config_file, Loader=yaml.FullLoader)
         config_file.close()
     except:
         log.log(log.LOG_ERROR, "Failed to load/parse config")


### PR DESCRIPTION
fixes the warning:

```
$ foreman-yml dump ./config/foreman.yml 2>&1 | head
/var/lib/foreman/foreman-yml/venv/lib/python2.7/site-packages/foreman_yml/main.py:110: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```